### PR TITLE
hllplus: allocate sparse delta slice and buffer lazily

### DIFF
--- a/hllplus/lazy_alloc_test.go
+++ b/hllplus/lazy_alloc_test.go
@@ -1,0 +1,115 @@
+package hllplus_test
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+
+	"github.com/bsm/zetasketch/hllplus"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// buildHLL constructs an HLL sketch with the given precisions and feeds it n
+// values drawn deterministically from seed, so that two calls with the same
+// arguments observe byte-for-byte identical input.
+func buildHLL(tb testing.TB, precision, sparsePrecision uint8, n int, seed int64) *hllplus.HLL {
+	tb.Helper()
+
+	h, err := hllplus.New(precision, sparsePrecision)
+	if err != nil {
+		tb.Fatalf("New(%d, %d): %v", precision, sparsePrecision, err)
+	}
+
+	rnd := rand.New(rand.NewSource(seed))
+	for i := 0; i < n; i++ {
+		h.Add(rnd.Uint64())
+	}
+	return h
+}
+
+func marshalHLL(tb testing.TB, h *hllplus.HLL) []byte {
+	tb.Helper()
+
+	b, err := proto.Marshal(h.Proto())
+	if err != nil {
+		tb.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// TestLazyAllocInvariant guards that lazily allocating the sparse delta slice and
+// buffer map does not change observable behavior. Across a wide low/high
+// cardinality range and a couple of precisions it asserts that the cardinality
+// estimate and the serialized bytes are stable and fully deterministic: two
+// independently built sketches over identical input must agree byte-for-byte, and
+// a serialize/deserialize round-trip must preserve the estimate. The sparse
+// buffer is a map, so this also pins down that serialization stays independent of
+// map iteration order.
+func TestLazyAllocInvariant(t *testing.T) {
+	precisions := []struct{ p, sp uint8 }{
+		{12, 17},
+		{15, 20},
+	}
+	cardinalities := []int{1, 10, 100, 10_000, 1_000_000}
+
+	const seed = 42
+
+	for _, pr := range precisions {
+		for _, n := range cardinalities {
+			if n >= 1_000_000 && testing.Short() {
+				continue
+			}
+
+			a := buildHLL(t, pr.p, pr.sp, n, seed)
+			b := buildHLL(t, pr.p, pr.sp, n, seed)
+
+			// (b) cardinality estimate is identical across independent builds.
+			estA, estB := a.Estimate(), b.Estimate()
+			if estA != estB {
+				t.Fatalf("p=%d sp=%d n=%d: estimates differ: %d != %d", pr.p, pr.sp, n, estA, estB)
+			}
+
+			// (a) serialized bytes are byte-identical across independent builds.
+			bytesA, bytesB := marshalHLL(t, a), marshalHLL(t, b)
+			if !bytes.Equal(bytesA, bytesB) {
+				t.Fatalf("p=%d sp=%d n=%d: serialized bytes differ (%d vs %d bytes)",
+					pr.p, pr.sp, n, len(bytesA), len(bytesB))
+			}
+
+			// round-trip: serialization faithfully restores the estimate.
+			restored, err := hllplus.NewFromProto(a.Proto())
+			if err != nil {
+				t.Fatalf("p=%d sp=%d n=%d: NewFromProto: %v", pr.p, pr.sp, n, err)
+			}
+			if got := restored.Estimate(); got != estA {
+				t.Fatalf("p=%d sp=%d n=%d: round-trip estimate changed: %d != %d", pr.p, pr.sp, n, got, estA)
+			}
+
+			// sanity: the estimate stays within HLL++ error bounds of the truth.
+			if d := estA - int64(n); d < -(int64(n)/20+2) || d > int64(n)/20+2 {
+				t.Fatalf("p=%d sp=%d n=%d: estimate %d outside tolerance", pr.p, pr.sp, n, estA)
+			}
+		}
+	}
+}
+
+var benchSink *hllplus.HLL
+
+// BenchmarkSparseLowCardinality measures the per-sketch heap cost of the common
+// low-cardinality case: construct a fresh sparse sketch and add a handful of
+// distinct values. Run with -benchmem to read B/op and allocs/op.
+func BenchmarkSparseLowCardinality(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		h, err := hllplus.New(12, 17)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for j := 0; j < 10; j++ {
+			h.Add(uint64(j) * 0x9e3779b97f4a7c15)
+		}
+		benchSink = h
+	}
+}

--- a/hllplus/sparse.go
+++ b/hllplus/sparse.go
@@ -35,7 +35,10 @@ func newSparseState(normalPrecision, sparsePrecision uint8, state []byte) *spars
 	}
 
 	// restore state from passed data (optional):
-	data := recycleDeltaSlice(maxDataLen)
+	// Allocate lazily with a small initial capacity instead of pre-sizing for the
+	// worst case. The delta slice is append-grown and the buffer is a map, so both
+	// grow on demand. maxDataLen/maxBufferLen are retained below as flush thresholds.
+	data := recycleDeltaSlice(64)
 	data.SetData(state)
 
 	return &sparseState{
@@ -43,7 +46,7 @@ func newSparseState(normalPrecision, sparsePrecision uint8, state []byte) *spars
 		sparsePrecision: sparsePrecision,
 
 		data:   data,
-		buffer: make(uint32Set, maxBufferLen),
+		buffer: make(uint32Set),
 
 		encodedFlag:  encodedFlag,
 		maxDataLen:   maxDataLen,


### PR DESCRIPTION
## Problem

The sparse HLL++ state pre-allocates its delta slice and buffer map for the worst case when a sketch is constructed. In streaming/aggregation pipelines that key HLL sketches by a high-cardinality grouping key, many low-cardinality sketches are held live simultaneously, and this worst-case preallocation dominates heap — most of those bytes are never touched because each sketch only ever sees a handful of distinct values.

## Change

Two allocations in `newSparseState` switch from worst-case sizing to lazy/minimal sizing:

- the delta slice starts at a small capacity instead of `maxDataLen`,
- the buffer map starts empty instead of being pre-sized to `maxBufferLen`.

The delta slice is append-grown and the buffer is a map, so both grow correctly on demand. `maxDataLen`/`maxBufferLen` are retained as flush thresholds — only their use as *allocation sizes* is dropped. Serialization output and cardinality estimates are unchanged; only the initial per-sketch heap footprint drops.

## Benchmark

Low-cardinality sparse sketch (construct + add 10 distinct values), `-benchmem -count=5`:

| | B/op | allocs/op |
|---|---|---|
| before (worst-case sizing) | 22298 | 10 |
| after (lazy sizing) | 520 | 9 |

## Tests

- Existing suite passes (`go test ./...`).
- Added `TestLazyAllocInvariant`: builds independent sketches over identical input across cardinalities {1, 10, 100, 10k, 1M} at precisions 12/17 and 15/20, asserting byte-identical serialization, identical estimates, and a serialize→deserialize round-trip that preserves the estimate.