### PR TITLE
chore: bump ginkgo/gomega/protobuf and target Go 1.26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.26.x]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/bsm/zetasketch
 
-go 1.19
+go 1.26.0
 
 require (
-	github.com/bsm/ginkgo v1.16.4
-	github.com/bsm/gomega v1.16.0
-	google.golang.org/protobuf v1.33.0
+	github.com/bsm/ginkgo v1.16.5
+	github.com/bsm/gomega v1.27.10
+	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/bsm/ginkgo v1.16.4 h1:pkHpo2VJRvI0NGlxCYi8qovww76L7+g82MgM+UBvH4A=
-github.com/bsm/ginkgo v1.16.4/go.mod h1:RabIZLzOCPghgHJKUqHZpqrQETA5AnF4aCSIYy5C1bk=
-github.com/bsm/gomega v1.16.0 h1:LEoRGHyYl3MqAcXgczKX/C3bxlxjl3gjP37PGvPNplw=
-github.com/bsm/gomega v1.16.0/go.mod h1:JifAceMQ4crZIWYUKrlGcmbN3bqHogVTADMD2ATsbwk=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
+github.com/bsm/ginkgo v1.16.5 h1:uTeeWv0Yx1PnDeCk76PFyGrOMVw3D+r9bTNKNcIjDdQ=
+github.com/bsm/ginkgo v1.16.5/go.mod h1:RabIZLzOCPghgHJKUqHZpqrQETA5AnF4aCSIYy5C1bk=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
+google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=


### PR DESCRIPTION
## What

- Test deps: `bsm/ginkgo` v1.16.4 → v1.16.5, `bsm/gomega` v1.16.0 → v1.27.10
- `google.golang.org/protobuf` v1.33.0 → v1.36.11
- `go` directive 1.19 → 1.26.0, and CI refreshed accordingly

## Why

`google.golang.org/protobuf` v1.36 requires Go 1.23+, so the previous `go 1.19` directive and the `[1.19.x, 1.20.x]` CI matrix no longer build. The matrix moves to `1.26.x` (latest stable), and the workflow actions (`checkout`/`cache`/`setup-go`) are bumped to current majors so the toolchain installs on present-day runners.

## Verification

`go vet ./...` and `go test ./...` pass under Go 1.26.0.